### PR TITLE
新規登録画面の実装

### DIFF
--- a/app/assets/javascripts/signups.coffee
+++ b/app/assets/javascripts/signups.coffee
@@ -1,3 +1,0 @@
-# Place all the behaviors and hooks related to the matching controller here.
-# All this logic will automatically be available in application.js.
-# You can use CoffeeScript in this file: http://coffeescript.org/

--- a/app/assets/javascripts/signups.coffee
+++ b/app/assets/javascripts/signups.coffee
@@ -1,0 +1,3 @@
+# Place all the behaviors and hooks related to the matching controller here.
+# All this logic will automatically be available in application.js.
+# You can use CoffeeScript in this file: http://coffeescript.org/

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -23,3 +23,4 @@
  @import 'side-bar';
  @import 'logout';
  @import './card_registration';
+ @import "signups.scss";

--- a/app/assets/stylesheets/signups.scss
+++ b/app/assets/stylesheets/signups.scss
@@ -1,0 +1,126 @@
+a { 
+  text-decoration: none;
+  margin: 0;
+  padding: 0;
+  height: 100%;
+  width: 100vw;
+}
+
+.wipper {
+  background-color: #eeeeee;
+  text-align: center;
+
+  .signup-header {
+    height: 128px;
+    width: 100%;
+    display: inline-block;
+    
+    &__logo {
+     margin: 40px 0 0;
+     display: inline-block;
+    }
+  }
+
+  .signup-main {
+    display: block;
+    font-family: 'Source Sans Pro', Helvetica , Arial, '游ゴシック体', 'YuGothic', 'メイリオ', 'Meiryo', sans-serif;
+
+    .signup-content {
+      background-color: #fff;
+      width: 700px;
+      margin: 0 auto;
+      &__title {
+       font-size: 22px;
+       padding: 32px;
+       border-bottom: 1px solid #f5f5f5;
+        h2 {
+          font-weight: bold;
+        }
+      }
+      &__form {
+        padding: 40px 40px 64px;
+      }
+      &__btns {
+        max-width: 343px;
+        margin: 0 auto;
+      }
+      &__btn {
+        margin: 0 auto;
+        display: block;
+        cursor: pointer;
+          .default-btn {
+            display: block;
+            width: 100%;
+            line-height: 48px;
+            font-size: 14px;
+            border: 1px solid;
+            transition: all ease-out .3s;
+            border-radius: 4px;
+            }
+          
+          &--email {
+            background-color: #ea352d;
+            color: #fff;
+            position: relative;
+            &-icon {
+              float: left;
+              color: #fff;
+              position: absolute;
+              top: 15px;
+              left: 16px;
+              font-size: 20px;
+          }
+          }
+          &--facebook {
+            margin: 16px 0 0;
+            background-color: #385185;
+            color: #fff;
+            position: relative;
+            &-icon {
+              float: left;
+              position: absolute;
+              top: 10px;
+              left: 15px;
+              font-size: 26px;
+            }
+          }
+          &--google {
+            margin: 16px 0 0;
+            background-color: #fff;
+            border: #979797 soild 1px;
+            color: #333;
+            display: inline-block;
+            position: relative;
+            &-icon {
+              float: left;
+              position: absolute;
+              font-size: 20px;
+              left: 15px;
+              top: 15px;
+            }
+          }
+        }
+    }
+  }
+  .signup-footer {
+    width: 456px;
+    height: 220px;
+    margin: 0 auto;
+    padding: 40px 0;
+    text-align: center;
+    .footer-links {
+      display: flex;
+      justify-content: space-around;
+      a {
+        font-size: 12px;
+        color:black;
+      }
+    }
+    &__logo {
+      margin: 40px auto 0;
+    }
+    .inc {
+      font-size: 13px;
+    }
+  }
+}

--- a/app/controllers/signups_controller.rb
+++ b/app/controllers/signups_controller.rb
@@ -1,0 +1,4 @@
+class SignupsController < ApplicationController
+  def index
+  end
+end

--- a/app/controllers/users/registrations_controller.rb
+++ b/app/controllers/users/registrations_controller.rb
@@ -8,7 +8,7 @@ class Users::RegistrationsController < Devise::RegistrationsController
   def new
     @user = User.new
   end
-
+  
   # POST /resource
   def create
     @user = User.new(sign_up_params)

--- a/app/helpers/signups_helper.rb
+++ b/app/helpers/signups_helper.rb
@@ -1,0 +1,2 @@
+module SignupsHelper
+end

--- a/app/views/items/index.html.haml
+++ b/app/views/items/index.html.haml
@@ -19,7 +19,7 @@
             = link_to "ログアウト", destroy_user_session_path, method: :delete, class: 'list--right__link'
           - else
             = link_to "ログイン", new_user_session_path, method: :get, class: 'list--right__link' 
-            = link_to "新規会員登録", new_user_registration_path, method: :get, class: 'list--right__link'
+            = link_to "新規会員登録", signups_path, method: :get, class: 'list--right__link'
   .main
     .main--vanner
       .content

--- a/app/views/shared/_sabfooter.html.haml
+++ b/app/views/shared/_sabfooter.html.haml
@@ -1,0 +1,13 @@
+.signup-footer
+  %nav
+    %ul.footer-links
+      %li
+        =link_to "プライバシーポリシー","#"
+      %li
+        =link_to "利用契約", "#"
+      %li 
+        =link_to "特定商取引に関する表記", "#"
+  .signup-footer__logo
+    =link_to image_tag "material/logo/logo-white.png", size: "180x40"
+  %p.inc
+    ©︎Furima,Inc.

--- a/app/views/shared/_sabfooter.html.haml
+++ b/app/views/shared/_sabfooter.html.haml
@@ -9,5 +9,5 @@
         =link_to "特定商取引に関する表記", "#"
   .signup-footer__logo
     =link_to image_tag "material/logo/logo-white.png", size: "180x40"
-  %p.inc
+  .inc
     ©︎Furima,Inc.

--- a/app/views/signups/index.html.haml
+++ b/app/views/signups/index.html.haml
@@ -2,7 +2,7 @@
   .signup-header
     .signup-header__logo
       = link_to root_path do
-        = image_tag src="material/logo/logo.png", size: "180x40"
+        = image_tag "material/logo/logo.png", size: "180x40"
 
   .signup-main
     .signup-content
@@ -22,4 +22,3 @@
               Googleで登録する
 
   = render "shared/sabfooter"
-  

--- a/app/views/signups/index.html.haml
+++ b/app/views/signups/index.html.haml
@@ -1,0 +1,28 @@
+.wipper
+  .signup-header
+    .signup-header__logo
+      = link_to root_path do
+        = image_tag src="material/logo/logo.png", size: "180x40"
+
+  .signup-main
+    .signup-content
+      .signup-content__title
+        %h2 新規会員登録
+      .signup-content__form
+        .signup-content__btns
+          .signup-content__btn
+            = link_to new_user_registration_path, class: "default-btn signup-content__btn--email" do
+              =icon('far', 'envelope', class: "signup-content__btn--email-icon")
+              メールアドレスで登録する
+            = link_to "https://www.facebook.com/", class: "default-btn signup-content__btn--facebook" do
+              =icon('fab', 'facebook-square', class: "signup-content__btn--facebook-icon")
+              Facebookで登録する
+            = link_to "#", class: "default-btn signup-content__btn--google" do
+              =icon('fab', 'google', class: "signup-content__btn--google-icon")
+              Googleで登録する
+
+  = render "shared/sabfooter"
+
+  
+
+  

--- a/app/views/signups/index.html.haml
+++ b/app/views/signups/index.html.haml
@@ -22,7 +22,4 @@
               Googleで登録する
 
   = render "shared/sabfooter"
-
-  
-
   

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -16,4 +16,7 @@ Rails.application.routes.draw do
       get '_card_registration'
     end
   end
+
+  resources :signups, only: [:index] do
+  end
 end

--- a/spec/controllers/signups_controller_spec.rb
+++ b/spec/controllers/signups_controller_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe SignupsController, type: :controller do
+
+end

--- a/spec/helpers/signups_helper_spec.rb
+++ b/spec/helpers/signups_helper_spec.rb
@@ -1,0 +1,15 @@
+require 'rails_helper'
+
+# Specs in this file have access to a helper object that includes
+# the SignupsHelper. For example:
+#
+# describe SignupsHelper do
+#   describe "string concat" do
+#     it "concats two strings with spaces" do
+#       expect(helper.concat_strings("this","that")).to eq("this that")
+#     end
+#   end
+# end
+RSpec.describe SignupsHelper, type: :helper do
+  pending "add some examples to (or delete) #{__FILE__}"
+end


### PR DESCRIPTION
# what
1. 新規登録画面のマークアップ作成とトップページ
1. パスの設置
   1. 「トップページ」→「新規会員登録」→「メールアドレスで登録する」パスの設置
   2. 新規会員登録ページのヘッダー（FURIMA）をクリックするとトップページに戻る

# why
新規登録を行う際に、必要な画面のため実装

1. https://gyazo.com/4065f15581ca7a358eebacdfd57fc866
1. i. https://gyazo.com/2eb2cd128cf1add7d3f0fb8714f72799
    ii. https://gyazo.com/cddd18759b13daac7036d3cde5ac51d8