### PR TITLE
商品のバリデーション設定

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -43,7 +43,7 @@ class ItemsController < ApplicationController
   private
 
   def item_params
-    params.require(:item).permit(:name, :description, :price, :status, :postage, :delivery_way, :delivery_area, :delivery_date, :category, :brand, :size, images_attributes:[:src, :_destroy, :id]).merge(user_id: current_user.id)
+    params.require(:item).permit(:name, :description, :price, :status, :postage, :delivery_way, :delivery_area, :delivery_day, :category, :brand, :size, images_attributes:[:src, :_destroy, :id]).merge(user_id: current_user.id)
   end
 
   def set_item

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -1,21 +1,25 @@
 class Item < ApplicationRecord
   belongs_to :user, optional: true
   has_many :images, dependent: :destroy
-  accepts_nested_attributes_for :images, allow_destroy: true
-  validates :name, :price, presence: true
+  accepts_nested_attributes_for :images, allow_destroy: true 
+  validates :images, :name, :description, :status, :postage, :delivery_way, :delivery_area, :delivery_day, :price, :category, presence: true
+  validates :images, length: { in: 1..10 }
+  validates :name, length: { in: 1..40 }
+  validates :description, length: { in: 1..1000 }
+  validates :price, numericality: { greater_than_or_equal_to: 1 }
 
   enum category: { 
-    "選択してください":0, "レディース": 1, "メンズ": 2, "ベビー・キッズ": 3, "インテリア・住まい・小物": 4, "本・音楽・ゲーム": 5,
+    "レディース": 1, "メンズ": 2, "ベビー・キッズ": 3, "インテリア・住まい・小物": 4, "本・音楽・ゲーム": 5,
     "おもちゃ・ホビー・グッズ": 6, "コスメ・香水・美容": 7, "家電・スマホ・カメラ": 8, "スポーツ・レジャー": 9, "ハンドメイド": 10,
     "チケット": 11, "自動車・オートバイ": 12, "その他": 13
-  }, _prefix: true
-  enum size: { "選択してください":0, "XXS以下": 1, "XS(SS)": 2, "S": 3, "M": 4, "L": 5, "XL(LL)": 6, "2XL(3L)": 7, "3XL(4L)": 8, "4XL(5L)以上": 9, "FREESIZE": 10}, _prefix: true
-  enum status: { "選択してください":0, "新品・未使用": 1, "未使用に近い": 2, "目立った傷や汚れなし":3, "やや傷や汚れあり":4, "傷や汚れあり":5, "全体的に状態が悪い":6},  _prefix: true
-  enum postage: { "選択してください":0, "送料込み（出品者負担)":1, "送料込み（出品者負担）":2, "着払い（購入者負担）":3, "着払い（購入者負担）":4},  _prefix: true
-  enum delivery_way: { "選択してください":0, "ゆうメール":1, "レターパック":2, "普通郵便":3, "クロネコヤマト":4, "ゆうパック":5, "クリックポスト":6, "ゆうパケット":7},  _prefix: true
-  enum delivery_day: { "選択してください":0, "1~2日で発送":1, "2〜3日で発送":2, "4〜7日で発送":3},  _prefix: true
+  }
+  enum size: { "XXS以下": 1, "XS(SS)": 2, "S": 3, "M": 4, "L": 5, "XL(LL)": 6, "2XL(3L)": 7, "3XL(4L)": 8, "4XL(5L)以上": 9, "FREESIZE": 10}
+  enum status: { "新品・未使用": 1, "未使用に近い": 2, "目立った傷や汚れなし":3, "やや傷や汚れあり":4, "傷や汚れあり":5, "全体的に状態が悪い":6}
+  enum postage: { "送料込み（出品者負担)":1, "送料込み（出品者負担）":2, "着払い（購入者負担）":3, "着払い（購入者負担）":4}
+  enum delivery_way: { "ゆうメール":1, "レターパック":2, "普通郵便":3, "クロネコヤマト":4, "ゆうパック":5, "クリックポスト":6, "ゆうパケット":7}
+  enum delivery_day: { "1~2日で発送":1, "2〜3日で発送":2, "4〜7日で発送":3}
   enum delivery_area:{
-    "選択してください":0,"北海道":1,"青森県":2,"岩手県":3,"宮城県":4,"秋田県":5,"山形県":6,"福島県":7,
+    "北海道":1,"青森県":2,"岩手県":3,"宮城県":4,"秋田県":5,"山形県":6,"福島県":7,
     "茨城県":8,"栃木県":9,"群馬県":10,"埼玉県":11,"千葉県":12,"東京都":13,"神奈川県":14,
     "新潟県":15,"富山県":16,"石川県":17,"福井県":18,"山梨県":19,"長野県":20,
     "岐阜県":21,"静岡県":22,"愛知県":23,"三重県":24,
@@ -23,5 +27,6 @@ class Item < ApplicationRecord
     "鳥取県":31,"島根県":32,"岡山県":33,"広島県":34,"山口県":35,
     "徳島県":36,"香川県":37,"愛媛県":38,"高知県":39,
     "福岡県":40,"佐賀県":41,"長崎県":42,"熊本県":43,"大分県":44,"宮崎県":45,"鹿児島県":46,"沖縄県":47
-  },  _prefix: true
+  }
+
 end

--- a/app/views/items/_form.html.haml
+++ b/app/views/items/_form.html.haml
@@ -35,13 +35,13 @@
         カテゴリー
         %span.item__image--alert 必須
         .category--input
-          = f.select :category, Item.categories.keys, {}, {class: 'select--wrap__default'}
+          = f.select :category, Item.categories.keys, { prompt: true}, {class: 'select--wrap__default'}
           %i.fas.fa-angle-down
       .item__size
         サイズ
         %span.item__image--optional 任意
         .size--input
-          = f.select :size, Item.sizes.keys, {}, {class: 'select--wrap__default'}
+          = f.select :size, Item.sizes.keys, { prompt: true}, {class: 'select--wrap__default'}
           %i.fas.fa-angle-down
       .item__brand
         ブランド
@@ -52,7 +52,7 @@
         商品の状態
         %span.item__image--alert 必須
         .status--input
-          = f.select :status, Item.statuses.keys, {}, {class: 'select--wrap__default'}
+          = f.select :status, Item.statuses.keys, { prompt: true}, {class: 'select--wrap__default'}
           %i.fas.fa-angle-down
     .item__delivery
       配送について
@@ -60,25 +60,25 @@
         配送料の負担
         %span.item__image--alert 必須
         .postage--input
-          = f.select :postage, Item.postages.keys, {}, {class: 'select--wrap__default'}
+          = f.select :postage, Item.postages.keys, { prompt: true}, {class: 'select--wrap__default'}
           %i.fas.fa-angle-down
       .item__delivery_way
         配送の方法
         %span.item__image--alert 必須
         .delivery_way--input
-          = f.select :delivery_way, Item.delivery_ways.keys, {}, {class: 'select--wrap__default'}
+          = f.select :delivery_way, Item.delivery_ways.keys, { prompt: true}, {class: 'select--wrap__default'}
           %i.fas.fa-angle-down
       .item__delivery_area
         発送元の地域
         %span.item__image--alert 必須
         .delivery_area--input
-          = f.select :delivery_area, Item.delivery_areas.keys, {}, {class: 'select--wrap__default'}
+          = f.select :delivery_area, Item.delivery_areas.keys, { prompt: true}, {class: 'select--wrap__default'}
           %i.fas.fa-angle-down
       .item__delivery_date
         発送までの日数
         %span.item__image--alert 必須
         .delivery_data--input
-          = f.select :delivery_day, Item.delivery_days.keys, {}, {class: 'select--wrap__default'}
+          = f.select :delivery_day, Item.delivery_days.keys, { prompt: true}, {class: 'select--wrap__default'}
           %i.fas.fa-angle-down
     .item__price
       販売価格

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -46,6 +46,21 @@ ja:
     models:
       user: ユーザー
       users_address: 住所
+      item: 商品
+      image: 画像
+      attributes:
+        item:
+          name: 商品名
+          description: 商品の説明
+          category: カテゴリー
+          size: サイズ
+          brand: ブランド
+          status: 商品の状態
+          postage: 配送料の負担
+          delivery_way: 配送の方法
+          delivery_area: 発送元の地域
+          delivery_day: 発送までの日数
+          price: 販売価格
   devise:
     confirmations:
       confirmed: アカウントを登録しました。

--- a/db/migrate/20200305120358_create_items.rb
+++ b/db/migrate/20200305120358_create_items.rb
@@ -2,15 +2,15 @@ class CreateItems < ActiveRecord::Migration[5.2]
   def change
     create_table :items do |t|
       t.string :name ,  null:false
-      t.text :description
-      t.integer :status, default: 0
-      t.integer :postage, default: 0
-      t.integer :delivery_way, default: 0
-      t.integer :delivery_area,default: 0
-      t.integer :delivery_day,default: 0
+      t.text :description, null:false
+      t.integer :status, null:false
+      t.integer :postage, null:false
+      t.integer :delivery_way, null:false
+      t.integer :delivery_area, null:false
+      t.integer :delivery_day, null:false
       t.integer :price, null:false
-      t.integer :category, default: 0
-      t.integer :size, default: 0 
+      t.integer :category, null:false
+      t.integer :size
       t.text :brand
       t.references :user, null: false, foreign_key: true
       t.timestamps

--- a/db/migrate/20200309115735_create_images.rb
+++ b/db/migrate/20200309115735_create_images.rb
@@ -1,7 +1,7 @@
 class CreateImages < ActiveRecord::Migration[5.2]
   def change
     create_table :images do |t|
-      t.string :src
+      t.string :src, null:false
       t.references :item, foreign_key: true
       t.timestamps
     end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -22,7 +22,7 @@ ActiveRecord::Schema.define(version: 2020_03_14_094456) do
   end
 
   create_table "images", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
-    t.string "src"
+    t.string "src", null: false
     t.bigint "item_id"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
@@ -31,15 +31,15 @@ ActiveRecord::Schema.define(version: 2020_03_14_094456) do
 
   create_table "items", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.string "name", null: false
-    t.text "description"
-    t.integer "status", default: 0
-    t.integer "postage", default: 0
-    t.integer "delivery_way", default: 0
-    t.integer "delivery_area", default: 0
-    t.integer "delivery_day", default: 0
+    t.text "description", null: false
+    t.integer "status", null: false
+    t.integer "postage", null: false
+    t.integer "delivery_way", null: false
+    t.integer "delivery_area", null: false
+    t.integer "delivery_day", null: false
     t.integer "price", null: false
-    t.integer "category", default: 0
-    t.integer "size", default: 0
+    t.integer "category", null: false
+    t.integer "size"
     t.text "brand"
     t.bigint "user_id", null: false
     t.datetime "created_at", null: false


### PR DESCRIPTION
# what
商品テーブルのバリデーションの設定
・必須項目の情報必ず入力
・画像は１０枚まで
・商品名は４０文字まで
・商品の説明は１０００文字まで
・販売価格は１円以上
・エラーメッセージの表示は未実装

# why
商品出品画面で必須となっている項目がないと
出品できないようにするため。