### PR TITLE
商品詳細画面の編集

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -41,11 +41,6 @@ class ItemsController < ApplicationController
     end
   end
 
-  def show
-    @item = Item.find(params[:id])
-    @images = @item.images
-  end
-
   private
 
   def item_params

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -41,6 +41,11 @@ class ItemsController < ApplicationController
     end
   end
 
+  def show
+    @item = Item.find(params[:id])
+    @images = @item.images
+  end
+
   private
 
   def item_params

--- a/app/views/items/_item.html.haml
+++ b/app/views/items/_item.html.haml
@@ -1,5 +1,5 @@
 .list
-  = link_to '#', class: "list__link" do
+  = link_to "/items/#{item.id}", class: "list__link" do
     - item.images.first(1).each do |image|
       = image_tag image.src.url, class: "list__image"
     .details

--- a/app/views/items/_item.html.haml
+++ b/app/views/items/_item.html.haml
@@ -1,5 +1,5 @@
 .list
-  = link_to "/items/#{item.id}", class: "list__link" do
+  = link_to item_path(item.id), class: "list__link" do
     - item.images.first(1).each do |image|
       = image_tag image.src.url, class: "list__image"
     .details

--- a/app/views/items/show.html.haml
+++ b/app/views/items/show.html.haml
@@ -5,10 +5,11 @@
   .item-box
     .item-content
     %h1.item-name
-      車
+      =@item.name
     .item-main-content
       .item-photo
-        =image_tag'material/pict/sample-itemdetail.jpeg'
+        - @item.images.first(1).each do |image|
+          = image_tag image.src.url
         .sold
       %table.item-detail
         %tbody
@@ -17,7 +18,7 @@
               出品者
             %td.item-detail__content
               = link_to mypage_users_path, class:"item-detail__content__user" do
-                user1
+                =@item.user.nickname
               .item-detail__content__users
                 .item-detail__content__users__evaluation-good
                 .item-detail__content__users__evaluation-normal
@@ -26,12 +27,13 @@
             %th.item-detail__title
               カテゴリー
             %td.item-detail__content
-              カテゴリー
+              = @item.category
           %tr
             %th.item-detail__title
               ブランド
             %td.item-detail__content
-              ブランド
+              = @item.brand
+              -# 下記、商品編集では選択項目がないのでそのままにしています
               .item-detail__content__content
                 >メンズ
               .item-detail__content__content__content
@@ -40,39 +42,39 @@
             %th.item-detail__title
               サイズ
             %td.item-detail__content
-              サイズ
+              = @item.size
           %tr
             %th.item-detail__title
               商品の状態
             %td.item-detail__content
-              商品の状態
+              = @item.status
           %tr
             %th.item-detail__title
               配送料の負担
             %td.item-detail__content
-              配送料の負担
+              = @item.postage
           %tr
             %th.item-detail__title
               配送の方法
             %td.item-detail__content
-              らくらくフリマ便
+              = @item.delivery_way
           %tr
             %th.item-detail__title
               配送元地域
             %td.item-detail__content
-              配送元地域
+              = @item.delivery_area
           %tr
             %th.item-detail__title
               配送日の目安
             %td.item-detail__content
-              配送日の目安
+              = @item.delivery_day
     .item-price
       %span.item-price__main
-        ¥50,000
+        = @item.price
       %span.item-price__tax
         （税込）
       %span.item-price__fee
-        送料込み
+        =@item.postage
       %p.item-buy-btn
         = link_to "購入画面に進む", "#", class: 'item-buy-btn__content'
       %p.item-edit-btn
@@ -85,8 +87,7 @@
       この商品はらくらくフリマ便を利用しているため、アプリからのみ購入できます。
     .item-description
       %p.item-description__content
-        車です
-        中古です
+        =@item.description
     .item-button
       .item-button__left
         %button.item-button__left__like

--- a/app/views/items/show.html.haml
+++ b/app/views/items/show.html.haml
@@ -33,11 +33,6 @@
               ブランド
             %td.item-detail__content
               = @item.brand
-              -# 下記、商品編集では選択項目がないのでそのままにしています
-              .item-detail__content__content
-                >メンズ
-              .item-detail__content__content__content
-                >トップス
           %tr
             %th.item-detail__title
               サイズ
@@ -70,7 +65,7 @@
               = @item.delivery_day
     .item-price
       %span.item-price__main
-        = @item.price
+        = "#{@item.price}円"
       %span.item-price__tax
         （税込）
       %span.item-price__fee


### PR DESCRIPTION
# what 
- トップページの商品をクリックすると商品詳細画面に遷移する
- 商品詳細は登録した情報と同じ内容になる

# why
商品詳細画面に遷移できるルートがなかったため実装