### PR TITLE
商品詳細ページから「編集」及び「削除」機能の実装

### DIFF
--- a/app/views/items/_item.html.haml
+++ b/app/views/items/_item.html.haml
@@ -13,6 +13,3 @@
             = icon('fas', 'fas fa-star')
             0
         (税込)
-
-  = link_to '編集', edit_item_path(item)
-  = link_to '削除', item_path(item), method: :delete 

--- a/app/views/items/show.html.haml
+++ b/app/views/items/show.html.haml
@@ -73,11 +73,11 @@
       %p.item-buy-btn
         = link_to "購入画面に進む", "#", class: 'item-buy-btn__content'
       %p.item-edit-btn
-        = link_to "商品の編集", "#", class: 'item-edit-btn__content'
+        = link_to "商品の編集", edit_item_path(@item.id), class: 'item-edit-btn__content'
       %p.item-stop-btn
         = link_to "出品を一旦停止する", "#", class: 'item-stop-btn__content'
       %p.item-destroy-btn
-        = link_to "この商品を削除する", "#", class: 'item-destroy-btn__content'
+        = link_to "この商品を削除する", item_path(@item.id), method: :delete, class: 'item-destroy-btn__content'
     %p.purchase-message
       この商品はらくらくフリマ便を利用しているため、アプリからのみ購入できます。
     .item-description


### PR DESCRIPTION
#What
①商品詳細ページから、商品編集画面への遷移
②商品詳細ページから、商品削除
③トップページの商品一覧から、編集・削除機能を削除

＃Why
出品した商品の編集及び削除は必要な機能のため
但し、ログインユーザーなら誰でも編集削除できる状態