### PR TITLE
商品出品（編集）エラーメッセージの表示＆成功時のflashメッセージ

### DIFF
--- a/app/assets/javascripts/items.js
+++ b/app/assets/javascripts/items.js
@@ -18,6 +18,7 @@ $(document).on('turbolinks:load', function() {
 
   // file_fieldのnameに動的なindexをつける為の配列
   let fileIndex = [1,2,3,4,5,6,7,8,9,10];
+  if ($('.js-file').length == 0) $('#image-box').append(buildFileField(fileIndex[0]));
   // 既に使われているindexを除外
   lastIndex = $('.js-file_group:last').data('index');
   fileIndex.splice(0, lastIndex);

--- a/app/assets/javascripts/items.js
+++ b/app/assets/javascripts/items.js
@@ -1,4 +1,5 @@
-$(document).on('turbolinks:load', ()=> {
+$(document).on('turbolinks:load', function() {
+
   // 画像用のinputを生成する関数
   const buildFileField = (num)=> {
     const html = `<div data-index="${num}" class="js-file_group">

--- a/app/assets/stylesheets/item_form.scss
+++ b/app/assets/stylesheets/item_form.scss
@@ -11,7 +11,7 @@ a:hover{
   margin: 0 auto;
   font-family: "Source Sans Pro", Helvetica, Arial, "游ゴシック体", "YuGothic", "メイリオ", "Meiryo", sans-serif;
   .errors__box{
-    color:#ea352d;;
+    color:#ea352d;
     padding: 10px;
     }
   #image-box{

--- a/app/assets/stylesheets/item_form.scss
+++ b/app/assets/stylesheets/item_form.scss
@@ -10,6 +10,10 @@ a:hover{
   width: 700px;
   margin: 0 auto;
   font-family: "Source Sans Pro", Helvetica, Arial, "游ゴシック体", "YuGothic", "メイリオ", "Meiryo", sans-serif;
+  .errors__box{
+    color:#ea352d;;
+    padding: 10px;
+    }
   #image-box{
     padding: 30px;
     font-size: 14px;

--- a/app/assets/stylesheets/items.scss
+++ b/app/assets/stylesheets/items.scss
@@ -3,7 +3,12 @@
   width: 100%;
   height: 100%;
   font-family: "Source Sans Pro", Helvetica, Arial, "游ゴシック体", "YuGothic", "メイリオ", "Meiryo", sans-serif;
-
+  .flash{
+    background-color:#3CCACE;
+    color:white;
+    text-align:center;
+    padding:10px;
+    }
   .main{
     &--vanner{
       width: 100%;

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -14,7 +14,7 @@ class ItemsController < ApplicationController
   def create
     @item = Item.new(item_params)
     if @item.save
-      redirect_to root_path
+      redirect_to root_path, notice: "商品を出品しました"
     else
       redirect_to new_item_path, flash: { error: @item.errors.full_messages }
     end

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -14,9 +14,9 @@ class ItemsController < ApplicationController
   def create
     @item = Item.new(item_params)
     if @item.save
-      redirect_to root_path, notice: "商品を出品しました"
+      redirect_to root_path
     else
-      render :new
+      redirect_to new_item_path, flash: { error: @item.errors.full_messages }
     end
   end
 
@@ -28,7 +28,7 @@ class ItemsController < ApplicationController
     if @item.update(item_params)
       redirect_to root_path, notice: "商品を更新しました"
     else
-      render :edit
+      rediect_to new_item_path
     end
   end
 

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -13,11 +13,10 @@ class ItemsController < ApplicationController
 
   def create
     @item = Item.new(item_params)
-    begin
-      @item.save!
-      redirect_to root_path
-    rescue ActiveRecord::RecordInvalid
-      redirect_to new_item_path
+    if @item.save
+      redirect_to root_path, notice: "商品を出品しました"
+    else
+      render :new
     end
   end
 
@@ -27,7 +26,7 @@ class ItemsController < ApplicationController
 
   def update
     if @item.update(item_params)
-      redirect_to root_path
+      redirect_to root_path, notice: "商品を更新しました"
     else
       render :edit
     end
@@ -35,7 +34,7 @@ class ItemsController < ApplicationController
 
   def destroy
     if @item.destroy
-      redirect_to root_path
+      redirect_to root_path, notice: '商品を削除しました'
     else
       render :edit
     end

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -3,10 +3,10 @@ class Item < ApplicationRecord
   has_many :images, dependent: :destroy
   accepts_nested_attributes_for :images, allow_destroy: true 
   validates :images, :name, :description, :status, :postage, :delivery_way, :delivery_area, :delivery_day, :price, :category, presence: true
-  validates :images, length: { in: 1..10 }
-  validates :name, length: { in: 1..40 }
-  validates :description, length: { in: 1..1000 }
-  validates :price, numericality: { greater_than_or_equal_to: 1 }
+  validates :images, length: { in: 1..10 , message: 'は１〜10枚添付してください' }
+  validates :name, length: { in: 1..40 , message: 'は40文字以内で入力してください' }
+  validates :description, length: { in: 1..1000 , message: 'は1000文字以内で入力してください' }
+  validates :price, numericality: { greater_than_or_equal_to: 1 , less_than_or_equal_to: 999999999 , message: 'は1〜999999999円で入力してください' }
 
   enum category: { 
     "レディース": 1, "メンズ": 2, "ベビー・キッズ": 3, "インテリア・住まい・小物": 4, "本・音楽・ゲーム": 5,

--- a/app/views/items/_form.html.haml
+++ b/app/views/items/_form.html.haml
@@ -1,4 +1,8 @@
 .item__content
+  - if @item.errors
+    %ul.errors__box
+      - @item.errors.full_messages.each do |message|
+        %li= message
   = form_for @item do |f|
     #image-box
       商品画像

--- a/app/views/items/_form.html.haml
+++ b/app/views/items/_form.html.haml
@@ -1,8 +1,8 @@
 .item__content
-  - if @item.errors
+  - if flash[:error].present?
     %ul.errors__box
-      - @item.errors.full_messages.each do |message|
-        %li= message
+      - flash[:error].each do |e|
+        %li= e
   = form_for @item do |f|
     #image-box
       商品画像

--- a/app/views/items/index.html.haml
+++ b/app/views/items/index.html.haml
@@ -1,4 +1,7 @@
 .wrapper
+  - if flash[:notice]
+    .flash
+      = flash[:notice]
   = render 'header'
   .main
     .main--vanner

--- a/config/application.rb
+++ b/config/application.rb
@@ -11,6 +11,7 @@ module FreemarketSample65c
     # Initialize configuration defaults for originally generated Rails version.
     config.load_defaults 5.2
     config.i18n.default_locale = :ja
+    config.action_view.field_error_proc = Proc.new { |html_tag, instance| html_tag }
     # Settings in config/environments/* take precedence over those specified here.
     # Application configuration can go into files in config/initializers
     # -- all .rb files in that directory are automatically loaded after loading

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -43,24 +43,24 @@ ja:
         house_number: 番地
         building_name: マンション・アパート名
         address_phone_number: 電話番号
+      item:
+        images: 画像
+        name: 商品名
+        description: 商品の説明
+        category: カテゴリー
+        size: サイズ
+        brand: ブランド
+        status: 商品の状態
+        postage: 配送料の負担
+        delivery_way: 配送の方法
+        delivery_area: 発送元の地域
+        delivery_day: 発送までの日数
+        price: 販売価格
     models:
       user: ユーザー
       users_address: 住所
       item: 商品
       image: 画像
-      attributes:
-        item:
-          name: 商品名
-          description: 商品の説明
-          category: カテゴリー
-          size: サイズ
-          brand: ブランド
-          status: 商品の状態
-          postage: 配送料の負担
-          delivery_way: 配送の方法
-          delivery_area: 発送元の地域
-          delivery_day: 発送までの日数
-          price: 販売価格
   devise:
     confirmations:
       confirmed: アカウントを登録しました。


### PR DESCRIPTION
# what
商品出品（編集）にエラーメッセージの表示
出品、編集、削除成功時にflashメッセージの表示

# why
エラーの際に同じページに飛ぶようにしていたが
何のエラーで戻っているのかがユーザーにとってわかりづらいため実装。
成功した場合はわかりやすいように画面で表示させた。

# 参考画像
エラー時の画面
https://gyazo.com/de387eb5d842851556b62bde63a2cbdb

成功時のflashメッセージ（出品、編集、削除時に各々のメッセージがでます）
https://gyazo.com/16756469a291aeb9ce4c34f264f9a312

