### PR TITLE
販売価格の下限の訂正

### DIFF
--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -3,10 +3,10 @@ class Item < ApplicationRecord
   has_many :images, dependent: :destroy
   accepts_nested_attributes_for :images, allow_destroy: true 
   validates :images, :name, :description, :status, :postage, :delivery_way, :delivery_area, :delivery_day, :price, :category, presence: true
-  validates :images, length: { in: 1..10 , message: 'は１〜10枚添付してください' }
-  validates :name, length: { in: 1..40 , message: 'は40文字以内で入力してください' }
+  validates :images, length: { in: 1..10, message: 'は１〜10枚添付してください' }
+  validates :name, length: { in: 1..40, message: 'は40文字以内で入力してください' }
   validates :description, length: { in: 1..1000 , message: 'は1000文字以内で入力してください' }
-  validates :price, numericality: { greater_than_or_equal_to: 51 , less_than_or_equal_to: 999_999_999 , message: 'は51〜999999999円で入力してください' }
+  validates :price, numericality: { greater_than_or_equal_to: 51, less_than_or_equal_to: 999_999_999, message: 'は51〜999999999円で入力してください' }
 
   enum category: { 
     "レディース": 1, "メンズ": 2, "ベビー・キッズ": 3, "インテリア・住まい・小物": 4, "本・音楽・ゲーム": 5,

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -6,7 +6,7 @@ class Item < ApplicationRecord
   validates :images, length: { in: 1..10 , message: 'は１〜10枚添付してください' }
   validates :name, length: { in: 1..40 , message: 'は40文字以内で入力してください' }
   validates :description, length: { in: 1..1000 , message: 'は1000文字以内で入力してください' }
-  validates :price, numericality: { greater_than_or_equal_to: 1 , less_than_or_equal_to: 999999999 , message: 'は1〜999999999円で入力してください' }
+  validates :price, numericality: { greater_than_or_equal_to: 51 , less_than_or_equal_to: 999999999 , message: 'は51〜999999999円で入力してください' }
 
   enum category: { 
     "レディース": 1, "メンズ": 2, "ベビー・キッズ": 3, "インテリア・住まい・小物": 4, "本・音楽・ゲーム": 5,

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -6,7 +6,7 @@ class Item < ApplicationRecord
   validates :images, length: { in: 1..10 , message: 'は１〜10枚添付してください' }
   validates :name, length: { in: 1..40 , message: 'は40文字以内で入力してください' }
   validates :description, length: { in: 1..1000 , message: 'は1000文字以内で入力してください' }
-  validates :price, numericality: { greater_than_or_equal_to: 51 , less_than_or_equal_to: 999999999 , message: 'は51〜999999999円で入力してください' }
+  validates :price, numericality: { greater_than_or_equal_to: 51 , less_than_or_equal_to: 999_999_999 , message: 'は51〜999999999円で入力してください' }
 
   enum category: { 
     "レディース": 1, "メンズ": 2, "ベビー・キッズ": 3, "インテリア・住まい・小物": 4, "本・音楽・ゲーム": 5,

--- a/app/views/items/_form.html.haml
+++ b/app/views/items/_form.html.haml
@@ -85,10 +85,10 @@
           = f.select :delivery_day, Item.delivery_days.keys, { prompt: true}, {class: 'select--wrap__default'}
           %i.fas.fa-angle-down
     .item__price
-      販売価格
+      販売価格 
       %span.item__image--alert 必須
       %br
-      = f.number_field :price , min: 1
+      = f.number_field :price , min: 51
       円
     .item--submit
       = f.submit


### PR DESCRIPTION
# what
販売価格を５１円以上からの出品可能に訂正

# why
商品購入で50円以下の購入がpayjpで許されていないので
最低価格を51円にしています。
ちなみに上限は999999999にしています。
これ以上だとエラーがでてしまう数字になっていたため制限しています。