### PR TITLE
商品詳細画面の条件分岐

### DIFF
--- a/app/assets/stylesheets/show.scss
+++ b/app/assets/stylesheets/show.scss
@@ -92,6 +92,7 @@
         display: inline-block;
         font-size: 16px;
       }
+    }
       .item-buy-btn{
         font-size: 25px;
         line-height: 60px;
@@ -144,7 +145,6 @@
           text-decoration: none;
         }
       }
-    }
     .purchase-message{
       color: skyblue;
       line-height: 2;

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -52,7 +52,7 @@ class ItemsController < ApplicationController
   
   def login_check
     unless user_signed_in?
-      redirect_to signups_path
+      redirect_to new_user_session_path
     end
   end
 end

--- a/app/views/items/show.html.haml
+++ b/app/views/items/show.html.haml
@@ -70,14 +70,19 @@
         （税込）
       %span.item-price__fee
         =@item.postage
+    - if user_signed_in?
+      -if @item.user_id == current_user.id
+        %p.item-edit-btn
+          = link_to "商品の編集", edit_item_path(@item.id), class: 'item-edit-btn__content'
+        %p.item-stop-btn
+          = link_to "出品を一旦停止する", "#", class: 'item-stop-btn__content'
+        %p.item-destroy-btn
+          = link_to "この商品を削除する", item_path(@item.id), method: :delete, class: 'item-destroy-btn__content'
+    - else
       %p.item-buy-btn
-        = link_to "購入画面に進む", "#", class: 'item-buy-btn__content'
-      %p.item-edit-btn
-        = link_to "商品の編集", edit_item_path(@item.id), class: 'item-edit-btn__content'
-      %p.item-stop-btn
-        = link_to "出品を一旦停止する", "#", class: 'item-stop-btn__content'
-      %p.item-destroy-btn
-        = link_to "この商品を削除する", item_path(@item.id), method: :delete, class: 'item-destroy-btn__content'
+        = link_to "購入画面に進む", new_user_session_path, class: 'item-buy-btn__content'
+              
+
     %p.purchase-message
       この商品はらくらくフリマ便を利用しているため、アプリからのみ購入できます。
     .item-description

--- a/app/views/items/show.html.haml
+++ b/app/views/items/show.html.haml
@@ -78,6 +78,9 @@
           = link_to "出品を一旦停止する", "#", class: 'item-stop-btn__content'
         %p.item-destroy-btn
           = link_to "この商品を削除する", item_path(@item.id), method: :delete, class: 'item-destroy-btn__content'
+      -else 
+        %p.item-buy-btn
+          = link_to "購入画面に進む", "#", class: 'item-buy-btn__content'
     - else
       %p.item-buy-btn
         = link_to "購入画面に進む", new_user_session_path, class: 'item-buy-btn__content'


### PR DESCRIPTION
# what
ログイン済みと未ログインで商品詳細画面の表示の条件分岐を実装
下記、3パターンに分けています。

1. 未ログイン：「商品購入」→クリックするとログイン画面へ
1. ログイン済み+自分で商品出品：「商品の編集」「一旦停止」「削除」
1. ログイン済み+商品出品していない：「商品購入」→パス指定していません（※別ブランチで実装中）

# why
ログイン済みユーザーと未ログインユーザで商品詳細画面の表示を変える必要があるため。