### PR TITLE
商品編集エラー時の修正

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -20,6 +20,10 @@ class ItemsController < ApplicationController
     end
   end
 
+  def show
+
+  end
+
   def edit
 
   end
@@ -28,7 +32,7 @@ class ItemsController < ApplicationController
     if @item.update(item_params)
       redirect_to root_path, notice: "商品を更新しました"
     else
-      rediect_to new_item_path
+      redirect_to edit_item_path, flash: { error: @item.errors.full_messages }
     end
   end
 
@@ -36,7 +40,7 @@ class ItemsController < ApplicationController
     if @item.destroy
       redirect_to root_path, notice: '商品を削除しました'
     else
-      render :edit
+      redirect_to root_path, notice: '商品の削除に失敗しました'
     end
   end
 

--- a/app/views/items/_form.html.haml
+++ b/app/views/items/_form.html.haml
@@ -45,7 +45,7 @@
         サイズ
         %span.item__image--optional 任意
         .size--input
-          = f.select :size, Item.sizes.keys, { prompt: true}, {class: 'select--wrap__default'}
+          = f.select :size, Item.sizes.keys, { include_blank:true, prompt: true}, {class: 'select--wrap__default'}
           %i.fas.fa-angle-down
       .item__brand
         ブランド


### PR DESCRIPTION
# what
商品編集のエラー時にnew_item_pathに飛ばしていたのを修正

# why
編集でエラーを出すと、新規出品ページにとぶようになっていたので
同じ編集画面にとんで、エラーメッセージもしっかりと出るようにした。
追加で任意のサイズに、未選択（空欄）の選択も追加しました。
（一度選んでしまうと空欄が選べなかったため）