### PR TITLE
商品詳細画面にて画像を複数表示＆クリックで表示変更

### DIFF
--- a/app/assets/javascripts/item_show.js
+++ b/app/assets/javascripts/item_show.js
@@ -1,0 +1,6 @@
+$(document).on('turbolinks:load', function() {
+  $('.image__list').click(function () {
+    var $src = $(this).attr('src');
+    $('.main__image').attr('src', $src);
+  });
+});

--- a/app/assets/stylesheets/items.scss
+++ b/app/assets/stylesheets/items.scss
@@ -276,6 +276,7 @@
             .list__image{
               height: 180px;
               width:230px;
+              object-fit: cover;
             }
             .details{
               padding: 16px;

--- a/app/assets/stylesheets/show.scss
+++ b/app/assets/stylesheets/show.scss
@@ -6,7 +6,7 @@
   .item-box{
     padding:25px 40px 40px;
     margin: 40px auto 0;
-    width: 600px;
+    width: 620px;
     border-style: solid;
     border-width: 0;
     background-color: white;
@@ -21,12 +21,26 @@
       margin: 20px 0 0;
       height: 400px;
       position: relative;
-      .item-photo{
+      .photo__box{
         float: left;
-        &__content{
-          min-width: 300px;
-          max-width: 300px;
-          min-height: 375px;
+        margin-right: 15px;
+        .photo__innner{
+          background-color: #d3d3d3;
+          .main__image{
+            width: 300px;
+            height: 300px;
+            object-fit: cover;
+          }
+          ul{
+            display: flex;
+            flex-wrap: wrap;
+            width: 300px;
+            .image__list{
+              width: 60px;
+              height: 60px;
+              object-fit: cover;
+            }
+          }
         }
       }
       .sold{
@@ -80,7 +94,7 @@
     }
     .item-price{
       text-align: center;
-      margin: 20px 0 0;
+      margin: 60px 0 0;
       &__main{
         margin: 0 16px 0 0;
         font-size: 50px;

--- a/app/views/items/show.html.haml
+++ b/app/views/items/show.html.haml
@@ -10,8 +10,7 @@
       .photo__box
         %ul.photo__innner
           %li
-            - @item.images.first(1).each do |image|
-              = image_tag image.src.url, class: "main__image"
+            = image_tag @item.images.first.src.url, class: "main__image"
             %ul
               - @item.images.each do |image|
                 %li

--- a/app/views/items/show.html.haml
+++ b/app/views/items/show.html.haml
@@ -7,9 +7,15 @@
     %h1.item-name
       =@item.name
     .item-main-content
-      .item-photo
-        - @item.images.first(1).each do |image|
-          = image_tag image.src.url
+      .photo__box
+        %ul.photo__innner
+          %li
+            - @item.images.first(1).each do |image|
+              = image_tag image.src.url, class: "main__image"
+            %ul
+              - @item.images.each do |image|
+                %li
+                  = image_tag image.src.url, class: "image__list"
         .sold
       %table.item-detail
         %tbody


### PR DESCRIPTION
# what
・詳細画面にて画像を複数表示
・画像をクリックするとメイン画像が入れ替わる

# why
画像が配列の一番目しか表示されなかったので
複数画像投稿できる意味がなかったので表示できるようにした。
メイン画像をクリックで変更して表示できるようにしてユーザーからの見えやすさをあげた。

# 参考画像
https://gyazo.com/f454b72a460800cdd13927445bd9e85b