### PR TITLE
新規アカウント登録時のパスワードの非常時⇒表示機能

### DIFF
--- a/app/assets/javascripts/password_switch.js
+++ b/app/assets/javascripts/password_switch.js
@@ -1,0 +1,11 @@
+$(document).on('turbolinks:load', function() {
+  $("#reveal_password").change(function(){
+    if($(this).prop('checked')){
+      $('#PWForm').attr('type','text');
+      $('#PWForm_confirmation').attr('type','text');
+    }else{
+      $('#PWForm').attr('type','password');
+      $('#PWForm_confirmation').attr('type','password');
+    }
+  });
+});

--- a/app/views/devise/registrations/new.html.haml
+++ b/app/views/devise/registrations/new.html.haml
@@ -24,7 +24,7 @@
             .form__new-user__group-space
               = f.label :パスワード, class: "form__new-user__group-text"
               %span.form__new-user__group--alert 必須
-              = f.password_field :password, autocomplete: "new-password", placeholder: "#{@minimum_password_length}文字以上の半角英数字", class: "def-input"
+              = f.password_field :password, autocomplete: "new-password", placeholder: "#{@minimum_password_length}文字以上の半角英数字", class: "def-input", id: "PWForm"
             - if @minimum_password_length
               %p.form-info-text 
                 ※英字と数字の両方を含めて設定してください
@@ -32,7 +32,7 @@
             .form__new-user__group-space
               = f.label :"パスワード(確認用)", class: "form__new-user__group-text"
               %span.form__new-user__group--alert 必須
-              = f.password_field :password_confirmation, autocomplete: "new-password", placeholder: "#{@minimum_password_length}文字以上の半角英数字", class: "def-input"
+              = f.password_field :password_confirmation, autocomplete: "new-password", placeholder: "#{@minimum_password_length}文字以上の半角英数字", class: "def-input", id: "PWForm_confirmation"
             .form__new-user__group-checkbox
               %input#reveal_password{type: "checkbox",  class: "checkbox-btn"}
               = f.label :reveal_password, "パスワードを表示する", class: "checkbox-defult"


### PR DESCRIPTION
# what
新規アカウント作成時に
パスワードを表示のチェックボックスをつけると表示されるようになる

# why
チェックボックスはあったが、実際にパスワードの表示ができなかったため
表示できるように変更した

# 参照画像
https://gyazo.com/fcc642b697dcd82a8706d8d9a6b7a0cb