### PR TITLE
SOLD表示の部分テンプレートの追加（商品詳細ページ）

### DIFF
--- a/app/views/items/show.html.haml
+++ b/app/views/items/show.html.haml
@@ -11,6 +11,7 @@
         %ul.photo__innner
           %li
             = image_tag @item.images.first.src.url, class: "main__image"
+            =render 'sold_display', item: @item
             %ul
               - @item.images.each do |image|
                 %li


### PR DESCRIPTION
# What
 商品詳細ページの商品画像にSOLD表示が出るように部分テンプレートを追記

# Why
 商品詳細ページでも売り切れていることが一目でわかるようにする為

https://gyazo.com/a4987119d25b5e5c2fd752d3891b20d1